### PR TITLE
Allow for theme checkout during provision.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .vagrant/
+ssh-keys/*
+!ssh-keys/README.md
 vagrant_ansible_inventory_default
 examples/prod/inventory
 config.yml

--- a/example.config.aws-jenkins.yml
+++ b/example.config.aws-jenkins.yml
@@ -59,6 +59,11 @@ drupal_mysql_dump: "/path/to/mysql-dump.sql.gz"
 # Set this to true if you wish to refresh the database on each provision.
 drupal_mysql_refresh: false
 
+# Optional git repository containing one or more themes.
+# drupal_theme_repository: "git@github.com:user/repo.git"
+# drupal_theme_version: "master"
+# drupal_theme_key: "/vagrant/ssh-keys/id_rsa"
+
 # Stage File Proxy URL
 # Provide an optional URL to proxy files to a remote location.
 # drupal_stage_file_proxy_url: "https://production-url.com"

--- a/example.config.aws-jenkins.yml
+++ b/example.config.aws-jenkins.yml
@@ -217,9 +217,9 @@ jenkins_plugins:
   - 'log-parser'
   - 'ghprb'
   - 'ansicolor'
-jenkins_github_repo: git@github.com:srowlands/govcms-autodeploy-test.git
-jenkins_github_url: https://github.com/srowlands/govcms-autodeploy-test
-jenkins_github_stub: srowlands/govcms-autodeploy-test
+jenkins_github_repo: "{{ drupal_theme_repository }}"
+jenkins_github_url: https://github.com/user/repository
+jenkins_github_stub: user/repository
 jenkins_description: "govCMS pull request environment builder"
 
 # AWS configuration.

--- a/example.config.aws.yml
+++ b/example.config.aws.yml
@@ -59,6 +59,11 @@ drupal_mysql_dump: "/path/to/mysql-dump.sql.gz"
 # Set this to true if you wish to refresh the database on each provision.
 drupal_mysql_refresh: false
 
+# Optional git repository containing one or more themes.
+# drupal_theme_repository: "git@github.com:user/repo.git"
+# drupal_theme_version: "master"
+# drupal_theme_key: "/vagrant/ssh-keys/id_rsa"
+
 # Stage File Proxy URL
 # Provide an optional URL to proxy files to a remote location.
 # drupal_stage_file_proxy_url: "https://production-url.com"

--- a/example.config.vm.yml
+++ b/example.config.vm.yml
@@ -200,39 +200,3 @@ solr_xmx: "128M"
 
 # Selenium configuration
 selenium_version: 2.46.0
-
-# Jenkins configuration.
-jenkins_http_host: "{{ vagrant_ip }}"
-jenkins_jobs:
-  - name: "govcms_pull_request_builder"
-    template: templates/govcms-jenkins.xml.j2
-jenkins_plugins:
-  - 'git'
-  - 'github-api'
-  - 'plain-credentials'
-  - 'token-macro'
-  - 'github'
-  - 'ssh-agent'
-  - 'build-flow-plugin'
-  - 'credentials'
-  - 'log-parser'
-  - 'ghprb'
-  - 'ansicolor'
-jenkins_github_repo: git@github.com:srowlands/govcms-autodeploy-test.git
-jenkins_github_url: https://github.com/srowlands/govcms-autodeploy-test
-jenkins_github_stub: srowlands/govcms-autodeploy-test
-jenkins_description: "govCMS pull request environment builder"
-
-# AWS configuration.
-aws_access_key_id: "INSERT_AWS_ACCESS_KEY"
-aws_secret_key: "INSERT_AWS_SECRET_KEY"
-aws_instance_type: "t2.micro"
-aws_region: "ap-southeast-2"
-aws_security_groups: ["default", "INSERT_AWS_SECURITY_GROUP"]
-
-# Provide path to a private key (for ssh into provisioned instance).
-aws_keypair_name: "INSERT_AWS_KEYPAIR_NAME"
-aws_ssh_private_key: "/path/to/keypair/file.pem"
-
-# By default use an Ubuntu ami
-aws_ami: "ami-69631053"

--- a/example.config.vm.yml
+++ b/example.config.vm.yml
@@ -60,6 +60,11 @@ drupal_mysql_dump: "/path/to/mysql-dump.sql.gz"
 # Set this to true if you wish to refresh the database on each provision.
 drupal_mysql_refresh: false
 
+# Optional git repository containing one or more themes.
+# drupal_theme_repository: "git@github.com:user/repo.git"
+# drupal_theme_version: "master"
+# drupal_theme_key: "/vagrant/ssh-keys/id_rsa"
+
 # Stage File Proxy URL
 # Provide an optional URL to proxy files to a remote location.
 # drupal_stage_file_proxy_url: "https://production-url.com"

--- a/example.config.yml
+++ b/example.config.yml
@@ -218,9 +218,9 @@ jenkins_plugins:
   - 'log-parser'
   - 'ghprb'
   - 'ansicolor'
-jenkins_github_repo: git@github.com:srowlands/govcms-autodeploy-test.git
-jenkins_github_url: https://github.com/srowlands/govcms-autodeploy-test
-jenkins_github_stub: srowlands/govcms-autodeploy-test
+jenkins_github_repo: "{{ drupal_theme_repository }}"
+jenkins_github_url: https://github.com/user/repository
+jenkins_github_stub: user/repository
 jenkins_description: "govCMS pull request environment builder"
 
 # AWS configuration.

--- a/example.config.yml
+++ b/example.config.yml
@@ -60,6 +60,11 @@ drupal_mysql_dump: "/path/to/mysql-dump.sql.gz"
 # Set this to true if you wish to refresh the database on each provision.
 drupal_mysql_refresh: false
 
+# Optional git repository containing one or more themes.
+# drupal_theme_repository: "git@github.com:user/repo.git"
+# drupal_theme_version: "master"
+# drupal_theme_key: "/vagrant/ssh-keys/id_rsa"
+
 # Stage File Proxy URL
 # Provide an optional URL to proxy files to a remote location.
 # drupal_stage_file_proxy_url: "https://production-url.com"

--- a/provisioning/tasks/install-site.yml
+++ b/provisioning/tasks/install-site.yml
@@ -29,3 +29,28 @@
     chdir={{ drupal_core_path }}
   when: "'Successful' not in drupal_site_installed.stdout"
   sudo: no
+
+- name: Clean out theme folder.
+  file: path={{ drupal_core_path }}/sites/all/themes state=absent
+  when: drupal_theme_repository is defined
+
+- name: Checkout theme repository if provided.
+  git: >
+    repo={{ drupal_theme_repository }}
+    dest={{ drupal_core_path }}/sites/all/themes/
+    version={{ drupal_theme_version }}
+    accept_hostkey=yes
+    force=yes
+    recursive=no
+  when: drupal_theme_repository is defined and drupal_theme_key is not defined
+
+- name: Checkout theme repository (with SSH key) if provided.
+  git: >
+    repo={{ drupal_theme_repository }}
+    dest={{ drupal_core_path }}/sites/all/themes/
+    version={{ drupal_theme_version }}
+    accept_hostkey=yes
+    force=yes
+    recursive=no
+    key_file={{ drupal_theme_key }}
+  when: drupal_theme_repository is defined and drupal_theme_key is defined

--- a/ssh-keys/README.md
+++ b/ssh-keys/README.md
@@ -1,0 +1,5 @@
+Place any SSH keys required in this folder.
+
+By default these keys will be available in `/vagrant/ssh-keys`.
+
+These are commonly used for the Jenkins CI setup and theme deployment.


### PR DESCRIPTION
Allows for optional git repository containing one or more themes and checking out to sites/all/themes.

Expects a private key provides in the new ssh-keys folder (can also be re-used for Jenkins private keys), or will check out anonymously if no key is provided.
