### PR TITLE
Update the vagrant box version

### DIFF
--- a/example.config.vm-acquiacloud.yml
+++ b/example.config.vm-acquiacloud.yml
@@ -2,7 +2,7 @@
 # `vagrant_box` can also be set to geerlingguy/centos6, geerlingguy/centos7,
 # geerlingguy/ubuntu1204, parallels/ubuntu-14.04, etc.
 vagrant_box: geerlingguy/ubuntu1404
-vagrant_box_version: 1.0.6
+vagrant_box_version: 1.1.4
 vagrant_user: vagrant
 
 # If you need to run multiple instances of Drupal VM, set a unique hostname,

--- a/example.config.vm.yml
+++ b/example.config.vm.yml
@@ -2,7 +2,7 @@
 # `vagrant_box` can also be set to geerlingguy/centos6, geerlingguy/centos7,
 # geerlingguy/ubuntu1204, parallels/ubuntu-14.04, etc.
 vagrant_box: geerlingguy/ubuntu1404
-vagrant_box_version: 1.0.6
+vagrant_box_version: 1.1.4
 vagrant_user: vagrant
 
 # If you need to run multiple instances of Drupal VM, set a unique hostname,

--- a/example.config.yml
+++ b/example.config.yml
@@ -2,7 +2,7 @@
 # `vagrant_box` can also be set to geerlingguy/centos6, geerlingguy/centos7,
 # geerlingguy/ubuntu1204, parallels/ubuntu-14.04, etc.
 vagrant_box: geerlingguy/ubuntu1404
-vagrant_box_version: 1.0.6
+vagrant_box_version: 1.1.4
 vagrant_user: vagrant
 
 # If you need to run multiple instances of Drupal VM, set a unique hostname,


### PR DESCRIPTION
Vagrant 1.0.6 is no longer available, change the default version to 1.1.4 to prevent confusion.